### PR TITLE
Add permission_callback for register_rest_route

### DIFF
--- a/src/blocks/latest-posts/block.php
+++ b/src/blocks/latest-posts/block.php
@@ -90,6 +90,7 @@ class LatestPostsBlock
         register_rest_route( 'alps-gutenberg-blocks', '/latest-posts/tags', [
             'methods' => 'GET',
             'callback' => [$this, 'listTags'],
+            'permission_callback' => '__return_true',
         ]);
     }
 


### PR DESCRIPTION
Since WordPress 5.5.0 calling `register_rest_route` without a `permission_callback` triggers a `_doing_it_wrong()` notice. ([source](https://github.com/WordPress/wordpress-develop/blob/d9d0fd64955bb8020b436fd6c01579f87a210c1e/src/wp-includes/rest-api.php#L93-L105)). This will trigger a user error if `WP_DEBUG` is truthy.